### PR TITLE
13: Fixed the edit newTaskName error

### DIFF
--- a/src/components/Task.jsx
+++ b/src/components/Task.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { toggleCompletion, deleteTask, editTask } from '../feature/tasks/taskSlice'
 import { toast } from 'react-toastify'
@@ -6,6 +6,11 @@ import { toast } from 'react-toastify'
 const Task = ({ task }) => {
   const [isEditing, setIsEditing] = useState(false)
   const [newTaskName, setTaskNewName] = useState(task.taskName);
+
+  useEffect(() => {
+    setTaskNewName(task.taskName)
+  }, [isEditing])
+  
 
   const dispatch = useDispatch()
 


### PR DESCRIPTION
There was a bug like when you click on edit and then remove the letters and then click cancel for edit and then again click on edit the newEditName will show the previous removed name of the task that one is fixed now with the help of useEffect hook